### PR TITLE
Feature/refactor get profile to use form data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.3",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -10,13 +10,13 @@ exports[`SSO SSO getAuthorizationURL with no domain or provider throws an error 
 
 exports[`SSO SSO getAuthorizationURL with state generates an authorize url with the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom%20state"`;
 
-exports[`SSO SSO getProfile with all information provided sends a request to the WorkOS api for a profile 1`] = `"/sso/token?client_id=proj_123&client_secret=sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU&grant_type=authorization_code&code=authorization_code"`;
+exports[`SSO SSO getProfile with all information provided sends a request to the WorkOS api for a profile 1`] = `"client_id=proj_123&client_secret=sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU&grant_type=authorization_code&code=authorization_code"`;
 
 exports[`SSO SSO getProfile with all information provided sends a request to the WorkOS api for a profile 2`] = `
 Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
-  "Content-Type": "application/x-www-form-urlencoded",
+  "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
   "User-Agent": "workos-node/0.2.1",
 }
 `;

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -17,7 +17,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.2.1",
+  "User-Agent": "workos-node/0.2.3",
 }
 `;
 

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -104,10 +104,7 @@ describe('SSO', () => {
           });
 
           expect(mock.history.post.length).toBe(1);
-
           const { data, headers } = mock.history.post[0];
-
-          console.log(data);
 
           expect(data).toMatchSnapshot();
           expect(headers).toMatchSnapshot();

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import querystring from 'querystring';
 
 import WorkOS from '../workos';
 
@@ -106,12 +105,12 @@ describe('SSO', () => {
 
           expect(mock.history.post.length).toBe(1);
 
-          const post = mock.history.post[0];
-          const requestURL = `${post.url}?${querystring.stringify(
-            post.params,
-          )}`;
-          expect(requestURL).toMatchSnapshot();
-          expect(post.headers).toMatchSnapshot();
+          const { data, headers } = mock.history.post[0];
+
+          console.log(data);
+
+          expect(data).toMatchSnapshot();
+          expect(headers).toMatchSnapshot();
           expect(profile).toMatchSnapshot();
         });
       });

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -35,14 +35,12 @@ export class SSO {
   }
 
   async getProfile({ code, projectID }: GetProfileOptions): Promise<Profile> {
-    const { data } = await this.workos.post('/sso/token', null, {
-      query: {
-        client_id: projectID,
-        client_secret: this.workos.key,
-        grant_type: 'authorization_code',
-        code,
-      },
-    });
+    const form = new URLSearchParams();
+    form.set('client_id', projectID);
+    form.set('client_secret', this.workos.key as string);
+    form.set('grant_type', 'authorization_code');
+    form.set('code', code);
+    const { data } = await this.workos.post('/sso/token', form);
 
     return data.profile as Profile;
   }


### PR DESCRIPTION
Changes the `WorkOS.sso.getProfile` method to send data as a `x-www-form-urlencoded` body instead of as query parameters.

This change is backwards compatible.