### PR TITLE
Rename endpoints to fetch Directory Groups and Users

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -27,39 +27,70 @@ describe('DirectorySync', () => {
   });
 
   describe('listGroups', () => {
-    it(`requests a Directory's Groups`, async () => {
-      mock.onGet().reply(200, {});
-      const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+    describe('with a Directory', () => {
+      it(`requests a Directory's Groups`, async () => {
+        mock.onGet().reply(200, {});
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-      await workos.directorySync.listGroups('dir_edp_123');
+        await workos.directorySync.listGroups({
+          directory: 'directory_123',
+        });
 
-      expect(mock.history.get[0].url).toEqual(
-        '/directories/dir_edp_123/groups',
-      );
+        expect(mock.history.get[0].params).toEqual({
+          directory: 'directory_123',
+        });
+        expect(mock.history.get[0].url).toEqual('/directory_groups');
+      });
+    });
+
+    describe('with a User', () => {
+      it(`requests a Directory's Groups`, async () => {
+        mock.onGet().reply(200, {});
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await workos.directorySync.listGroups({
+          user: 'directory_usr_123',
+        });
+
+        expect(mock.history.get[0].params).toEqual({
+          user: 'directory_usr_123',
+        });
+        expect(mock.history.get[0].url).toEqual('/directory_groups');
+      });
     });
   });
 
   describe('listUsers', () => {
-    it(`requests a Directory's Users`, async () => {
-      mock.onGet().reply(200, {});
-      const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+    describe('with a Directory', () => {
+      it(`requests a Directory's Users`, async () => {
+        mock.onGet().reply(200, {});
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-      await workos.directorySync.listUsers('dir_edp_123');
+        await workos.directorySync.listUsers({
+          directory: 'directory_123',
+        });
 
-      expect(mock.history.get[0].url).toEqual('/directories/dir_edp_123/users');
+        expect(mock.history.get[0].params).toEqual({
+          directory: 'directory_123',
+        });
+        expect(mock.history.get[0].url).toEqual('/directory_users');
+      });
     });
-  });
 
-  describe('listUserGroups', () => {
-    it(`requests a User's Groups`, async () => {
-      mock.onGet().reply(200, {});
-      const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+    describe('with a Group', () => {
+      it(`requests a Directory's Users`, async () => {
+        mock.onGet().reply(200, {});
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-      await workos.directorySync.listUserGroups('dir_edp_123', 'dir_usr_123');
+        await workos.directorySync.listUsers({
+          group: 'directory_grp_123',
+        });
 
-      expect(mock.history.get[0].url).toEqual(
-        '/directories/dir_edp_123/users/dir_usr_123/groups',
-      );
+        expect(mock.history.get[0].params).toEqual({
+          group: 'directory_grp_123',
+        });
+        expect(mock.history.get[0].url).toEqual('/directory_users');
+      });
     });
   });
 

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -4,7 +4,8 @@ import { List } from '../common/interfaces/list.interface';
 import { Group } from './interfaces/group.interface';
 import { User } from './interfaces/user.interface';
 import { ListDirectoriesOptions } from './interfaces/list-directories-options.interface';
-import { PaginationOptions } from '../common/interfaces/pagination-options.interface';
+import { ListGroupsOptions } from './interfaces/list-groups-options.interface';
+import { ListUsersOptions } from './interfaces/list-users-options.interface';
 
 export class DirectorySync {
   constructor(private readonly workos: WorkOS) {}
@@ -16,32 +17,13 @@ export class DirectorySync {
     return data;
   }
 
-  async listGroups(
-    directoryID: string,
-    options?: PaginationOptions,
-  ): Promise<List<Group>> {
-    const { data } = await this.workos.get(
-      `/directories/${directoryID}/groups`,
-      options,
-    );
+  async listGroups(options: ListGroupsOptions): Promise<List<Group>> {
+    const { data } = await this.workos.get(`/directory_groups`, options);
     return data;
   }
 
-  async listUsers(
-    directoryID: string,
-    options?: PaginationOptions,
-  ): Promise<List<User>> {
-    const { data } = await this.workos.get(
-      `/directories/${directoryID}/users`,
-      options,
-    );
-    return data;
-  }
-
-  async listUserGroups(directoryID: string, userID: string): Promise<Group[]> {
-    const { data } = await this.workos.get(
-      `/directories/${directoryID}/users/${userID}/groups`,
-    );
+  async listUsers(options: ListUsersOptions): Promise<List<User>> {
+    const { data } = await this.workos.get(`/directory_users`, options);
     return data;
   }
 

--- a/src/directory-sync/interfaces/list-groups-options.interface.ts
+++ b/src/directory-sync/interfaces/list-groups-options.interface.ts
@@ -1,0 +1,6 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
+export interface ListGroupsOptions extends PaginationOptions {
+  directory?: string;
+  user?: string;
+}

--- a/src/directory-sync/interfaces/list-users-options.interface.ts
+++ b/src/directory-sync/interfaces/list-users-options.interface.ts
@@ -1,0 +1,6 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
+export interface ListUsersOptions extends PaginationOptions {
+  directory?: string;
+  group?: string;
+}


### PR DESCRIPTION
* Uses `/directory_users` instead of `/directories/:id/users`
* Uses `/directory_groups` instead of `/directories/:id/groups`