### PR TITLE
Add method to fetch Audit Trail events

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   resetMocks: true,
   restoreMocks: true,
   verbose: true,
+  testEnvironment: "node",
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   roots: ['<rootDir>/src'],
   transform: {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.4.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/audit-trail/audit-trail.spec.ts
+++ b/src/audit-trail/audit-trail.spec.ts
@@ -1,11 +1,12 @@
 import axios from 'axios';
 import MockAdapater from 'axios-mock-adapter';
 
-import WorkOS from '../workos';
+import { EventOptions } from './interfaces/event-options.interface';
 import { UnauthorizedException } from '../common/exceptions';
+import WorkOS from '../workos';
 
 const mock = new MockAdapater(axios);
-const event = {
+const event: EventOptions = {
   group: 'WorkOS',
   actor_name: 'WorkOS@example.com',
   actor_id: 'user_1',
@@ -94,6 +95,105 @@ describe('AuditTrail', () => {
         await expect(
           workos.auditTrail.createEvent(event),
         ).rejects.toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('listEvents', () => {
+    describe('With no filters', () => {
+      it('Returns all events', async () => {
+        mock.onGet().reply(200, {
+          data: [
+            {
+              object: 'event',
+              id: 'evt_0',
+              group: 'foo-corp.com',
+              latitude: null,
+              longitude: null,
+              location: '::1',
+              type: 'r',
+              actor_name: 'demo@foo-corp.com',
+              actor_id: 'user_0',
+              target_name: 'http_request',
+              target_id: '',
+              metadata: {},
+              occurred_at: new Date(),
+              action: {
+                object: 'event_action',
+                id: 'evt_action_0',
+                name: 'user.searched_directories',
+              },
+            },
+            {
+              object: 'event',
+              id: 'evt_1',
+              group: 'workos.com',
+              location: '::1',
+              latitude: null,
+              longitude: null,
+              type: 'r',
+              actor_name: 'foo@example.com',
+              actor_id: 'user_1',
+              target_name: 'api_key_query',
+              target_id: 'key_0',
+              metadata: {
+                description: 'User viewed API key.',
+                x_request_id: '',
+              },
+              occurred_at: new Date('2020-07-31T14:27:00.384Z'),
+              action: {
+                object: 'event_action',
+                id: 'evt_action_1',
+                name: 'user.viewed_api_key',
+                project_id: 'project_0',
+              },
+            },
+          ],
+          listMetadata: { before: null, after: null },
+        });
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+        const events = await workos.auditTrail.listEvents();
+
+        expect(events.data).toHaveLength(2);
+      });
+    });
+
+    describe('With a filter', () => {
+      it('Returns events that match the filter', async () => {
+        mock.onGet().reply(200, {
+          data: [
+            {
+              object: 'event',
+              id: 'evt_0',
+              group: 'foo-corp.com',
+              latitude: null,
+              longitude: null,
+              location: '::1',
+              type: 'r',
+              actor_name: 'demo@foo-corp.com',
+              actor_id: 'user_0',
+              target_name: 'http_request',
+              target_id: '',
+              metadata: {},
+              occurred_at: new Date(),
+              action: {
+                object: 'event_action',
+                id: 'evt_action_0',
+                name: 'user.searched_directories',
+              },
+            },
+          ],
+          listMetadata: { before: null, after: null },
+        });
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+        const events = await workos.auditTrail.listEvents({
+          action: ['user.searched_directories'],
+        });
+
+        expect(events.data).toHaveLength(1);
+        expect(events.data[0].action.name).toEqual('user.searched_directories');
       });
     });
   });

--- a/src/audit-trail/audit-trail.ts
+++ b/src/audit-trail/audit-trail.ts
@@ -1,11 +1,22 @@
 import { CreateEventOptions } from './interfaces/create-event-options.interface';
-import { Event } from '../common/interfaces';
+import { Event } from './interfaces/event.interface';
+import { EventOptions } from './interfaces/event-options.interface';
+import { List } from '../common/interfaces/list.interface';
+import { ListEventsOptions } from './interfaces/list-events-options.interface';
 import WorkOS from '../workos';
 
 export class AuditTrail {
   constructor(private readonly workos: WorkOS) {}
 
-  async createEvent(event: Event, { idempotencyKey }: CreateEventOptions = {}) {
+  async createEvent(
+    event: EventOptions,
+    { idempotencyKey }: CreateEventOptions = {},
+  ) {
     await this.workos.post('/events', event, { idempotencyKey });
+  }
+
+  async listEvents(options?: ListEventsOptions): Promise<List<Event>> {
+    const { data } = await this.workos.get('/events', options);
+    return data;
   }
 }

--- a/src/audit-trail/interfaces/event-options.interface.ts
+++ b/src/audit-trail/interfaces/event-options.interface.ts
@@ -1,4 +1,4 @@
-export interface Event {
+export interface EventOptions {
   group: string;
   actor_name: string;
   actor_id: string;

--- a/src/audit-trail/interfaces/event.interface.ts
+++ b/src/audit-trail/interfaces/event.interface.ts
@@ -1,0 +1,25 @@
+export interface EventAction {
+  object: 'event_action';
+  id: string;
+  name: string;
+  project_id: string;
+}
+
+export interface Event {
+  object: 'event';
+  id: string;
+  group: string;
+  location: string;
+  latitude: string;
+  longitude: string;
+  type: 'c' | 'r' | 'u' | 'd';
+  actor_name: string;
+  actor_id: string;
+  target_name: string;
+  target_id: string;
+  occurred_at: Date;
+  action: EventAction;
+  metadata?: {
+    [key: string]: string;
+  };
+}

--- a/src/audit-trail/interfaces/list-events-options.interface.ts
+++ b/src/audit-trail/interfaces/list-events-options.interface.ts
@@ -1,0 +1,17 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+
+export interface ListEventsOptions extends PaginationOptions {
+  group?: string[];
+  action?: string[];
+  action_type?: string[];
+  actor_name?: string[];
+  actor_id?: string[];
+  target_name?: string[];
+  target_id?: string[];
+  occurred_at?: string;
+  occurred_at_gt?: string;
+  occurred_at_gte?: string;
+  occurred_at_lt?: string;
+  occurred_at_lte?: string;
+  search?: string;
+}

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,4 +1,3 @@
-export { Event } from './event.interface';
 export { HttpException } from './http-exception.interface';
 export { UnprocessableEntityError } from './unprocessable-entity-error.interface';
 export { WorkOSOptions } from './workos-options.interface';

--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -1,5 +1,5 @@
 export interface Directory {
-  object: 'directory_endpoint';
+  object: 'directory';
   id: string;
   bearer_token?: string;
   domain: string;

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -17,7 +17,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.3.0",
+  "User-Agent": "workos-node/0.4.0",
 }
 `;
 


### PR DESCRIPTION
* Removing `Event` from common types
* Re-factoring current `Event` to `EventOptions` when creating events
* Creating `Event` for returned Audit Trail events
* Bump version to 0.4.0
* Update old snapshots