### PR TITLE
Add createOrganization to Portal

### DIFF
--- a/src/portal/fixtures/create-organization-invalid.json
+++ b/src/portal/fixtures/create-organization-invalid.json
@@ -1,0 +1,1 @@
+{ "message": "An Organization with the domain example.com already exists." }

--- a/src/portal/fixtures/create-organization.json
+++ b/src/portal/fixtures/create-organization.json
@@ -1,0 +1,12 @@
+{
+  "name": "Test Organization",
+  "object": "organization",
+  "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
+  "domains": [
+    {
+      "domain": "example.com",
+      "object": "organization_domain",
+      "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
+    }
+  ]
+}

--- a/src/portal/portal.ts
+++ b/src/portal/portal.ts
@@ -7,6 +7,21 @@ import { Organization } from './interfaces/organization.interface';
 export class Portal {
   constructor(private readonly workos: WorkOS) {}
 
+  async createOrganization({
+    domains,
+    name,
+  }: {
+    domains: string[];
+    name: string;
+  }): Promise<Organization> {
+    const { data } = await this.workos.post('/organizations', {
+      domains,
+      name,
+    });
+
+    return data;
+  }
+
   async listOrganizations(
     options?: ListOrganizationsOptions,
   ): Promise<List<Organization>> {


### PR DESCRIPTION
* Adds the ability to create an organization via the SDK for use
  with the Admin Portal.