### PR TITLE
Rename listOrganizations arg "domain" to "domains"

### DIFF
--- a/src/portal/interfaces/list-organizations-options.interface.ts
+++ b/src/portal/interfaces/list-organizations-options.interface.ts
@@ -1,5 +1,5 @@
 import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
 
 export interface ListOrganizationsOptions extends PaginationOptions {
-  domain?: string;
+  domains?: string[];
 }

--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -113,11 +113,11 @@ describe('Portal', () => {
         mock.onGet().reply(200, listOrganizationsFixture);
 
         const { data } = await workos.portal.listOrganizations({
-          domain: 'example.com',
+          domains: ['example.com'],
         });
 
         expect(mock.history.get[0].params).toEqual({
-          domain: 'example.com',
+          domains: ['example.com'],
         });
 
         expect(mock.history.get[0].url).toEqual('/organizations');


### PR DESCRIPTION
* Modifies the arg to accept an array of strings, instead of a
  string.