### PR TITLE
Expose `connection_id` on Profile Objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0",
+  "version": "0.8.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -17,12 +17,13 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.7.0",
+  "User-Agent": "workos-node/0.8.0",
 }
 `;
 
 exports[`SSO SSO getProfile with all information provided sends a request to the WorkOS api for a profile 3`] = `
 Object {
+  "connection_id": "conn_123",
   "connection_type": "OktaSAML",
   "email": "foo@test.com",
   "first_name": "foo",

--- a/src/sso/interfaces/profile.interface.ts
+++ b/src/sso/interfaces/profile.interface.ts
@@ -3,6 +3,7 @@ import { ConnectionType } from './connection-type.enum';
 export interface Profile {
   id: string;
   idp_id: string;
+  connection_id: string;
   connection_type: ConnectionType;
   email: string;
   first_name?: string;

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -90,6 +90,7 @@ describe('SSO', () => {
             profile: {
               id: 'prof_123',
               idp_id: '123',
+              connection_id: 'conn_123',
               connection_type: 'OktaSAML',
               email: 'foo@test.com',
               first_name: 'foo',


### PR DESCRIPTION
This PR introduces the following changes:

* Passes the `connection_id` Profile object attribute through to the SDK. We currently expose `connection_id` via the `/sso/token` API endpoint.
* Updates the SDK version to `0.8.0`.