### PR TITLE
Use the correct parameter name for `redirect_uri`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.2",
+  "version": "0.8.3",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/passwordless/passwordless.spec.ts
+++ b/src/passwordless/passwordless.spec.ts
@@ -27,7 +27,7 @@ describe('Passwordless', () => {
         expect(session.object).toEqual('passwordless_session');
 
         expect(JSON.parse(mock.history.post[0].data).email).toEqual(email);
-        expect(JSON.parse(mock.history.post[0].data).redirectURI).toEqual(
+        expect(JSON.parse(mock.history.post[0].data).redirect_uri).toEqual(
           redirectURI,
         );
         expect(mock.history.post[0].url).toEqual('/passwordless/sessions');

--- a/src/passwordless/passwordless.ts
+++ b/src/passwordless/passwordless.ts
@@ -6,10 +6,14 @@ import { SendSessionResponse } from './interfaces/send-session-response.interfac
 export class Passwordless {
   constructor(private readonly workos: WorkOS) {}
 
-  async createSession(
-    options: CreatePasswordlessSessionOptions,
-  ): Promise<PasswordlessSession> {
-    const { data } = await this.workos.post('/passwordless/sessions', options);
+  async createSession({
+    redirectURI,
+    ...options
+  }: CreatePasswordlessSessionOptions): Promise<PasswordlessSession> {
+    const { data } = await this.workos.post('/passwordless/sessions', {
+      ...options,
+      redirect_uri: redirectURI,
+    });
     return data;
   }
 

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -17,7 +17,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.8.2",
+  "User-Agent": "workos-node/0.8.3",
 }
 `;
 


### PR DESCRIPTION
This PR fixes an issue with creating a passwordless session where we were using the wrong name when passing the `redirect_uri` up to the API.