### PR TITLE
Removing project_id from directory and event interfaces

### DIFF
--- a/src/audit-trail/interfaces/event.interface.ts
+++ b/src/audit-trail/interfaces/event.interface.ts
@@ -2,7 +2,6 @@ export interface EventAction {
   object: 'event_action';
   id: string;
   name: string;
-  project_id: string;
 }
 
 export interface Event {

--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -5,7 +5,6 @@ export interface Directory {
   domain: string;
   external_key: string;
   name: string;
-  project_id: string;
   state: 'unlinked' | 'linked';
   type: string;
 }


### PR DESCRIPTION
https://app.clubhouse.io/workos/story/4514/node-remove-project-id-from-directory-and-event-interfaces

Removes `project_id` from the directory and event interfaces