### PR TITLE
Resolve an issue where we were not properly sending `returnUrl` to the API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.3",
+  "version": "0.8.4",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -60,6 +60,7 @@ describe('Portal', () => {
         const subject = await workos.portal.generateLink({
           intent: GeneratePortalLinkIntent.SSO,
           organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
+          returnUrl: 'https://www.example.com',
         });
 
         expect(subject.link).toEqual(

--- a/src/portal/portal.ts
+++ b/src/portal/portal.ts
@@ -35,7 +35,7 @@ export class Portal {
     const { data } = await this.workos.post('/portal/generate_link', {
       intent,
       organization,
-      returnUrl,
+      return_url: returnUrl,
     });
 
     return data;

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -17,7 +17,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.8.3",
+  "User-Agent": "workos-node/0.8.4",
 }
 `;
 


### PR DESCRIPTION
* We need to translate `returnUrl` (the natural casing in our Node SDK) to
  `return_url` which our API will accept.