### PR TITLE
Add getConnection and listConnections methods

### DIFF
--- a/src/sso/interfaces/list-connections-options.interface.ts
+++ b/src/sso/interfaces/list-connections-options.interface.ts
@@ -1,0 +1,7 @@
+import { PaginationOptions } from '../../common/interfaces/pagination-options.interface';
+import { ConnectionType } from './connection-type.enum';
+
+export interface ListConnectionsOptions extends PaginationOptions {
+  connection_type?: ConnectionType;
+  domain?: string;
+}

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -222,5 +222,17 @@ describe('SSO', () => {
         expect(mock.history.get[0].url).toEqual('/connections/conn_123');
       });
     });
+
+    describe('listConnections', () => {
+      it(`requests a list of Connections`, async () => {
+        const mock = new MockAdapter(axios);
+        mock.onGet().reply(200, {});
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await workos.sso.listConnections();
+
+        expect(mock.history.get[0].url).toEqual('/connections');
+      });
+    });
   });
 });

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -210,5 +210,17 @@ describe('SSO', () => {
         });
       });
     });
+
+    describe('getConnection', () => {
+      it(`requests a Connection`, async () => {
+        const mock = new MockAdapter(axios);
+        mock.onGet().reply(200, {});
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        await workos.sso.getConnection('conn_123');
+
+        expect(mock.history.get[0].url).toEqual('/connections/conn_123');
+      });
+    });
   });
 });

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -4,6 +4,8 @@ import { AuthorizationURLOptions } from './interfaces/authorization-url-options.
 import { Connection } from './interfaces/connection.interface';
 import { CreateConnectionOptions } from './interfaces/create-connection-options.interface';
 import { GetProfileOptions } from './interfaces/get-profile-options.interface';
+import { List } from '../common/interfaces/list.interface';
+import { ListConnectionsOptions } from './interfaces/list-connections-options.interface';
 import { Profile } from './interfaces/profile.interface';
 import { PromoteDraftConnectionOptions } from './interfaces/promote-draft-connection-options.interface';
 import { WorkOS } from '../workos';
@@ -57,6 +59,13 @@ export class SSO {
     const { data } = await this.workos.post('/sso/token', form);
 
     return data.profile as Profile;
+  }
+
+  async listConnections(
+    options?: ListConnectionsOptions,
+  ): Promise<List<Connection>> {
+    const { data } = await this.workos.get(`/connections`, options);
+    return data;
   }
 
   async promoteDraftConnection({ token }: PromoteDraftConnectionOptions) {

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -43,6 +43,11 @@ export class SSO {
     return `${this.workos.baseURL}/sso/authorize?${query}`;
   }
 
+  async getConnection(id: string): Promise<Connection> {
+    const { data } = await this.workos.get(`/connections/${id}`);
+    return data;
+  }
+
   async getProfile({ code, clientID }: GetProfileOptions): Promise<Profile> {
     const form = new URLSearchParams();
     form.set('client_id', clientID);


### PR DESCRIPTION
https://linear.app/workos/issue/SDK-25/add-get-connections-for-node-sdk

Adds a `getConnection` method wrapping the `/connections/:id` endpoint and a `listConnections` method wrapping the `/connections` endpoint