### PR TITLE
Remove Unneeded Attribute from `Directory` Interface

### DIFF
--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -1,7 +1,6 @@
 export interface Directory {
   object: 'directory';
   id: string;
-  bearer_token?: string;
   domain: string;
   external_key: string;
   name: string;


### PR DESCRIPTION
This PR introduces the following changes:

- Removes `bearer_token` attribute from `Directory` interface