### PR TITLE
Update `ConnectionTypes` Interface

### DIFF
--- a/src/sso/interfaces/connection-type.enum.ts
+++ b/src/sso/interfaces/connection-type.enum.ts
@@ -1,4 +1,14 @@
 export enum ConnectionType {
+  ADFSSAML = 'ADFSSAML',
   AzureSAML = 'AzureSAML',
+  GenericOIDC = 'GenericOIDC',
+  GenericSAML = 'GenericSAML',
+  GoogleOAuth = 'GoogleOAuth',
+  GoogleSAML = 'GoogleSAML',
+  MagicLink = 'MagicLink',
   OktaSAML = 'OktaSAML',
+  OneLoginSAML = 'OneLoginSAML',
+  PingFederateSAML = 'PingFederateSAML',
+  PingOneSAML = 'PingOneSAML',
+  VMwareSAML = 'VMwareSAML',
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Updates available properties of the `ConnectionTypes` interface to support [those offered by the WorkOS API](https://workos.com/docs/reference#profile-connection_type).