### PR TITLE
Add `organization_id` Option to `listConnections`

### DIFF
--- a/src/sso/interfaces/list-connections-options.interface.ts
+++ b/src/sso/interfaces/list-connections-options.interface.ts
@@ -4,4 +4,5 @@ import { ConnectionType } from './connection-type.enum';
 export interface ListConnectionsOptions extends PaginationOptions {
   connection_type?: ConnectionType;
   domain?: string;
+  organization_id?: string;
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds support for an `organization_id` option to the `listConnections` method. Allows for retrieving a list of all Connections associated with the given `organization_id`.