### PR TITLE
Add `invalid_credentials` to Directory Interface `state`

### DIFF
--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -5,6 +5,6 @@ export interface Directory {
   external_key: string;
   name: string;
   environment_id: string;
-  state: 'unlinked' | 'linked';
+  state: 'unlinked' | 'linked' | 'invalid_credentials';
   type: string;
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds `invalid_credentials` as a possible value for the Directory interface `state` attribute. This reflects the most up-to-date, available values for the Directory state enum provided by the WorkOS API.