### PR TITLE
feat(workos-node): Make `domains` optional when creating Organizations

### DIFF
--- a/src/portal/portal.ts
+++ b/src/portal/portal.ts
@@ -12,7 +12,7 @@ export class Portal {
     domains,
     name,
   }: {
-    domains: string[];
+    domains?: string[];
     name: string;
   }): Promise<Organization> {
     const { data } = await this.workos.post('/organizations', {


### PR DESCRIPTION
Domains aren't required in the API when creating Organizations. This PR makes the argument optional.