### PR TITLE
Export `UserWithGroups` at the top-level

### DIFF
--- a/src/directory-sync/interfaces/index.ts
+++ b/src/directory-sync/interfaces/index.ts
@@ -3,4 +3,4 @@ export { Group } from './group.interface';
 export { ListDirectoriesOptions } from './list-directories-options.interface';
 export { ListGroupsOptions } from './list-groups-options.interface';
 export { ListUsersOptions } from './list-users-options.interface';
-export { User } from './user.interface';
+export { User, UserWithGroups } from './user.interface';


### PR DESCRIPTION
So that `import { UserWithGroups } from '@workos-inc/node'` works as expected.