### PR TITLE
Fix data returned from `generateLink`

### DIFF
--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -58,13 +58,13 @@ describe('Portal', () => {
         it('returns an Admin Portal link', async () => {
           mock.onPost().reply(201, generateLink);
 
-          const subject = await workos.portal.generateLink({
+          const adminPortalLink = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.SSO,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
             returnUrl: 'https://www.example.com',
           });
 
-          expect(subject.link).toEqual(
+          expect(adminPortalLink).toEqual(
             'https://id.workos.com/portal/launch?secret=secret',
           );
         });
@@ -74,13 +74,13 @@ describe('Portal', () => {
         it('returns an Admin Portal link', async () => {
           mock.onPost().reply(201, generateLink);
 
-          const subject = await workos.portal.generateLink({
+          const adminPortalLink = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.DSync,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
             returnUrl: 'https://www.example.com',
           });
 
-          expect(subject.link).toEqual(
+          expect(adminPortalLink).toEqual(
             'https://id.workos.com/portal/launch?secret=secret',
           );
         });

--- a/src/portal/portal.ts
+++ b/src/portal/portal.ts
@@ -38,7 +38,7 @@ export class Portal {
       return_url: returnUrl,
     });
 
-    return data;
+    return data.link;
   }
 
   async listOrganizations(


### PR DESCRIPTION
The data returned from the `portal/generate_link` endpoint is in the form `{ "link": "<LINK>" }`, but the return type of `generateLink` in the SDK is a `string`.

This PR extracts the `link` property from the API response and returns it so that the runtime type matches the static type.