### PR TITLE
Change generate link return type

### DIFF
--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -58,13 +58,13 @@ describe('Portal', () => {
         it('returns an Admin Portal link', async () => {
           mock.onPost().reply(201, generateLink);
 
-          const adminPortalLink = await workos.portal.generateLink({
+          const subject = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.SSO,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
             returnUrl: 'https://www.example.com',
           });
 
-          expect(adminPortalLink).toEqual(
+          expect(subject.link).toEqual(
             'https://id.workos.com/portal/launch?secret=secret',
           );
         });
@@ -74,13 +74,13 @@ describe('Portal', () => {
         it('returns an Admin Portal link', async () => {
           mock.onPost().reply(201, generateLink);
 
-          const adminPortalLink = await workos.portal.generateLink({
+          const subject = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.DSync,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
             returnUrl: 'https://www.example.com',
           });
 
-          expect(adminPortalLink).toEqual(
+          expect(subject.link).toEqual(
             'https://id.workos.com/portal/launch?secret=secret',
           );
         });

--- a/src/portal/portal.spec.ts
+++ b/src/portal/portal.spec.ts
@@ -58,13 +58,13 @@ describe('Portal', () => {
         it('returns an Admin Portal link', async () => {
           mock.onPost().reply(201, generateLink);
 
-          const subject = await workos.portal.generateLink({
+          const { link } = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.SSO,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
             returnUrl: 'https://www.example.com',
           });
 
-          expect(subject.link).toEqual(
+          expect(link).toEqual(
             'https://id.workos.com/portal/launch?secret=secret',
           );
         });
@@ -74,13 +74,13 @@ describe('Portal', () => {
         it('returns an Admin Portal link', async () => {
           mock.onPost().reply(201, generateLink);
 
-          const subject = await workos.portal.generateLink({
+          const { link } = await workos.portal.generateLink({
             intent: GeneratePortalLinkIntent.DSync,
             organization: 'org_01EHQMYV6MBK39QC5PZXHY59C3',
             returnUrl: 'https://www.example.com',
           });
 
-          expect(subject.link).toEqual(
+          expect(link).toEqual(
             'https://id.workos.com/portal/launch?secret=secret',
           );
         });

--- a/src/portal/portal.ts
+++ b/src/portal/portal.ts
@@ -31,7 +31,7 @@ export class Portal {
     intent: GeneratePortalLinkIntent;
     organization: string;
     returnUrl?: string;
-  }): Promise<string> {
+  }): Promise<{ link: string }> {
     const { data } = await this.workos.post('/portal/generate_link', {
       intent,
       organization,

--- a/src/portal/portal.ts
+++ b/src/portal/portal.ts
@@ -38,7 +38,7 @@ export class Portal {
       return_url: returnUrl,
     });
 
-    return data.link;
+    return data;
   }
 
   async listOrganizations(


### PR DESCRIPTION
Rather than the approach taken in #363, this PR changes the return type of `generateLink` to match the data being returned.

This is consistent with the usage we show in the docs.