### PR TITLE
v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.10",
+  "version": "0.10.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.9.10",
+  "User-Agent": "workos-node/0.10.0",
 }
 `;
 
@@ -49,7 +49,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.9.10",
+  "User-Agent": "workos-node/0.10.0",
 }
 `;
 


### PR DESCRIPTION
Release `v0.10.0` of `workos-node`.

This is a breaking change due to the changes to the signature of `portal.generateLink`.