### PR TITLE
Expose `idp_id` for directory users

### DIFF
--- a/src/directory-sync/interfaces/user.interface.ts
+++ b/src/directory-sync/interfaces/user.interface.ts
@@ -3,6 +3,7 @@ import { Group } from './group.interface';
 export interface User {
   id: string;
   raw_attributes: any;
+  idp_id: string;
   first_name: string;
   emails: {
     type: string;


### PR DESCRIPTION
This PR exposes the `idp_id` field for directory users.

Resolves SDK-99.