### PR TITLE
Remove deprecated Connection fields

### DIFF
--- a/src/sso/interfaces/connection.interface.ts
+++ b/src/sso/interfaces/connection.interface.ts
@@ -9,19 +9,13 @@ export interface ConnectionDomain {
 export interface Connection {
   object: 'connection';
   id: string;
+  organization_id: string;
+  name: string;
+  connection_type: ConnectionType;
   state: 'draft' | 'active' | 'inactive';
   /**
    * @deprecated The status parameter has been deprecated. Please use state.
    */
   status: 'linked' | 'unlinked';
-  name: string;
-  connection_type: ConnectionType;
-  oauth_uid: string;
-  oauth_secret: string;
-  oauth_redirect_uri: string;
-  saml_entity_id: string;
-  saml_idp_url: string;
-  saml_relying_party_trust_cert: string;
-  saml_x509_certs: string;
   domains: ConnectionDomain[];
 }


### PR DESCRIPTION
This PR removes the following deprecated fields from `Connection`s:

- `oauth_uid`
- `oauth_secret`
- `oauth_redirect_uri`
- `saml_entity_id`
- `saml_idp_url`
- `saml_relying_party_trust_cert`
- `saml_x509_certs`

We also expose the following new field: `organization_id`.

This is a breaking change.

Resolves SDK-139.