### PR TITLE
Remove support for deprecated `projectID` parameter

### DIFF
--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -8,39 +8,9 @@ exports[`SSO SSO getAuthorizationURL with a provider generates an authorize url 
 
 exports[`SSO SSO getAuthorizationURL with no custom api hostname generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
-exports[`SSO SSO getAuthorizationURL with no custom api hostname with projectID instead of clientID generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
-
 exports[`SSO SSO getAuthorizationURL with no domain or provider throws an error for incomplete arguments 1`] = `"Incomplete arguments. Need to specify either a 'connection', 'domain', or 'provider'."`;
 
 exports[`SSO SSO getAuthorizationURL with state generates an authorize url with the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom%20state"`;
-
-exports[`SSO SSO getProfileAndToken with a projectID instead of clientID sends a request to the WorkOS api for a profile 1`] = `"client_id=proj_123&client_secret=sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU&grant_type=authorization_code&code=authorization_code"`;
-
-exports[`SSO SSO getProfileAndToken with a projectID instead of clientID sends a request to the WorkOS api for a profile 2`] = `
-Object {
-  "Accept": "application/json, text/plain, */*",
-  "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
-  "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.10.3",
-}
-`;
-
-exports[`SSO SSO getProfileAndToken with a projectID instead of clientID sends a request to the WorkOS api for a profile 3`] = `
-Object {
-  "connection_id": "conn_123",
-  "connection_type": "OktaSAML",
-  "email": "foo@test.com",
-  "first_name": "foo",
-  "id": "prof_123",
-  "idp_id": "123",
-  "last_name": "bar",
-  "raw_attributes": Object {
-    "email": "foo@test.com",
-    "first_name": "foo",
-    "last_name": "bar",
-  },
-}
-`;
 
 exports[`SSO SSO getProfileAndToken with all information provided sends a request to the WorkOS api for a profile 1`] = `"client_id=proj_123&client_secret=sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU&grant_type=authorization_code&code=authorization_code"`;
 

--- a/src/sso/interfaces/authorization-url-options.interface.ts
+++ b/src/sso/interfaces/authorization-url-options.interface.ts
@@ -1,20 +1,8 @@
-export interface CommonAuthorizationURLOptions {
+export interface AuthorizationURLOptions {
+  clientID: string;
   connection?: string;
   domain?: string;
   provider?: string;
   redirectURI: string;
   state?: string;
 }
-
-export type AuthorizationURLOptions =
-  | ({
-      clientID: string;
-      projectID?: never;
-    } & CommonAuthorizationURLOptions)
-  | ({
-      clientID?: never;
-      /**
-       * @deprecated The projectID parameter has been deprecated. Please use clientID.
-       */
-      projectID: string;
-    } & CommonAuthorizationURLOptions);

--- a/src/sso/interfaces/get-profile-and-token-options.interface.ts
+++ b/src/sso/interfaces/get-profile-and-token-options.interface.ts
@@ -1,16 +1,4 @@
-export interface CommonGetProfileAndTokenOptions {
+export interface GetProfileAndTokenOptions {
+  clientID: string;
   code: string;
 }
-
-export type GetProfileAndTokenOptions =
-  | ({
-      clientID: string;
-      projectID?: never;
-    } & CommonGetProfileAndTokenOptions)
-  | ({
-      clientID?: never;
-      /**
-       * @deprecated The projectID parameter has been deprecated. Please use clientID.
-       */
-      projectID: string;
-    } & CommonGetProfileAndTokenOptions);

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -18,19 +18,6 @@ describe('SSO', () => {
 
           expect(url).toMatchSnapshot();
         });
-        describe('with projectID instead of clientID', () => {
-          it('generates an authorize url with the default api hostname', () => {
-            const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
-
-            const url = workos.sso.getAuthorizationURL({
-              domain: 'lyft.com',
-              projectID: 'proj_123',
-              redirectURI: 'example.com/sso/workos/callback',
-            });
-
-            expect(url).toMatchSnapshot();
-          });
-        });
       });
 
       describe('with no domain or provider', () => {
@@ -134,48 +121,13 @@ describe('SSO', () => {
           });
 
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
-          const { access_token: accessToken, profile } =
-            await workos.sso.getProfileAndToken({
-              code: 'authorization_code',
-              clientID: 'proj_123',
-            });
-
-          expect(mock.history.post.length).toBe(1);
-          const { data, headers } = mock.history.post[0];
-
-          expect(data).toMatchSnapshot();
-          expect(headers).toMatchSnapshot();
-          expect(accessToken).toBe('01DMEK0J53CVMC32CK5SE0KZ8Q');
-          expect(profile).toMatchSnapshot();
-        });
-      });
-      describe('with a projectID instead of clientID', () => {
-        it('sends a request to the WorkOS api for a profile', async () => {
-          const mock = new MockAdapter(axios);
-          mock.onPost('/sso/token').reply(200, {
-            access_token: '01DMEK0J53CVMC32CK5SE0KZ8Q',
-            profile: {
-              id: 'prof_123',
-              idp_id: '123',
-              connection_id: 'conn_123',
-              connection_type: 'OktaSAML',
-              email: 'foo@test.com',
-              first_name: 'foo',
-              last_name: 'bar',
-              raw_attributes: {
-                email: 'foo@test.com',
-                first_name: 'foo',
-                last_name: 'bar',
-              },
-            },
+          const {
+            access_token: accessToken,
+            profile,
+          } = await workos.sso.getProfileAndToken({
+            code: 'authorization_code',
+            clientID: 'proj_123',
           });
-
-          const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
-          const { access_token: accessToken, profile } =
-            await workos.sso.getProfileAndToken({
-              code: 'authorization_code',
-              projectID: 'proj_123',
-            });
 
           expect(mock.history.post.length).toBe(1);
           const { data, headers } = mock.history.post[0];

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -121,13 +121,11 @@ describe('SSO', () => {
           });
 
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
-          const {
-            access_token: accessToken,
-            profile,
-          } = await workos.sso.getProfileAndToken({
-            code: 'authorization_code',
-            clientID: 'proj_123',
-          });
+          const { access_token: accessToken, profile } =
+            await workos.sso.getProfileAndToken({
+              code: 'authorization_code',
+              clientID: 'proj_123',
+            });
 
           expect(mock.history.post.length).toBe(1);
           const { data, headers } = mock.history.post[0];

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -28,7 +28,6 @@ export class SSO {
     clientID,
     domain,
     provider,
-    projectID,
     redirectURI,
     state,
   }: AuthorizationURLOptions): string {
@@ -42,7 +41,7 @@ export class SSO {
       connection,
       domain,
       provider,
-      client_id: clientID ?? projectID,
+      client_id: clientID,
       redirect_uri: redirectURI,
       response_type: 'code',
       state,
@@ -59,17 +58,13 @@ export class SSO {
   async getProfileAndToken({
     code,
     clientID,
-    projectID,
   }: GetProfileAndTokenOptions): Promise<ProfileAndToken> {
-    const form = new URLSearchParams();
-    if (clientID) {
-      form.set('client_id', clientID);
-    } else if (projectID) {
-      form.set('client_id', projectID);
-    }
-    form.set('client_secret', this.workos.key as string);
-    form.set('grant_type', 'authorization_code');
-    form.set('code', code);
+    const form = new URLSearchParams({
+      client_id: clientID,
+      client_secret: this.workos.key as string,
+      grant_type: 'authorization_code',
+      code,
+    });
 
     const { data } = await this.workos.post('/sso/token', form);
     return data;


### PR DESCRIPTION
This PR removes support for the deprecated `projectID` parameter.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-161.