### PR TITLE
v1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 WorkOS
+Copyright (c) 2021 WorkOS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.3",
+  "version": "1.0.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -19,7 +19,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/0.10.3",
+  "User-Agent": "workos-node/1.0.0",
 }
 `;
 


### PR DESCRIPTION
## Breaking Changes

- `sso.getProfile` has been renamed to `sso.getProfileAndToken` (#385)
  - The return type has also been changed from `Promise<Profile>` to `Promise<ProfileAndToken>`
- Organization operations have been moved from the `portal` namespace to `organizations` (#390)
  - `portal.createOrganization` &rarr; `organizations.createOrganization`
  - `portal.listOrganizations` &rarr; `organizations.listOrganizations`
-  `sso.createConnection` and `sso.promoteDraftConnection` have been removed (#392)
- The following fields have been removed from `Connection`s (#379):
  - `oauth_uid`
  - `oauth_secret`
  - `oauth_redirect_uri`
  - `saml_entity_id`
  - `saml_idp_url`
  - `saml_relying_party_trust_cert`
  - `saml_x509_certs`

## New Features

- Added `organizations.updateOrganization` (#388)
- Exposed `organization_id` on `Connection`s (#379)

## Removed Deprecations

- The deprecated `projectID` parameter for `sso.getAuthorizationURL` and `sso.getProfileAndToken` (formerly `sso.getProfile`) has been fully removed. The `clientID` parameter should be used instead (#389)

Resolves SDK-182.