### PR TITLE
Add `getProfile` method

### DIFF
--- a/src/audit-trail/audit-trail.ts
+++ b/src/audit-trail/audit-trail.ts
@@ -16,7 +16,9 @@ export class AuditTrail {
   }
 
   async listEvents(options?: ListEventsOptions): Promise<List<Event>> {
-    const { data } = await this.workos.get('/events', options);
+    const { data } = await this.workos.get('/events', {
+      query: options,
+    });
     return data;
   }
 }

--- a/src/common/interfaces/get-options.interface.ts
+++ b/src/common/interfaces/get-options.interface.ts
@@ -1,0 +1,4 @@
+export interface GetOptions {
+  query?: Record<string, any>;
+  accessToken?: string;
+}

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,4 +1,5 @@
-export { UnprocessableEntityError } from './unprocessable-entity-error.interface';
-export { WorkOSOptions } from './workos-options.interface';
-export { PostOptions } from './post-options.interface';
-export { PutOptions } from './put-options.interface';
+export * from './get-options.interface';
+export * from './post-options.interface';
+export * from './put-options.interface';
+export * from './unprocessable-entity-error.interface';
+export * from './workos-options.interface';

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -13,7 +13,9 @@ export class DirectorySync {
   async listDirectories(
     options?: ListDirectoriesOptions,
   ): Promise<List<Directory>> {
-    const { data } = await this.workos.get('/directories', options);
+    const { data } = await this.workos.get('/directories', {
+      query: options,
+    });
     return data;
   }
 
@@ -22,12 +24,16 @@ export class DirectorySync {
   }
 
   async listGroups(options: ListGroupsOptions): Promise<List<Group>> {
-    const { data } = await this.workos.get(`/directory_groups`, options);
+    const { data } = await this.workos.get(`/directory_groups`, {
+      query: options,
+    });
     return data;
   }
 
   async listUsers(options: ListUsersOptions): Promise<List<UserWithGroups>> {
-    const { data } = await this.workos.get(`/directory_users`, options);
+    const { data } = await this.workos.get(`/directory_users`, {
+      query: options,
+    });
     return data;
   }
 

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -12,7 +12,9 @@ export class Organizations {
   async listOrganizations(
     options?: ListOrganizationsOptions,
   ): Promise<List<Organization>> {
-    const { data } = await this.workos.get('/organizations', options);
+    const { data } = await this.workos.get('/organizations', {
+      query: options,
+    });
 
     return data;
   }

--- a/src/sso/interfaces/get-profile-options.interface.ts
+++ b/src/sso/interfaces/get-profile-options.interface.ts
@@ -1,0 +1,3 @@
+export interface GetProfileOptions {
+  accessToken: string;
+}

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -138,6 +138,37 @@ describe('SSO', () => {
       });
     });
 
+    describe('getProfile', () => {
+      it('calls the `/sso/profile` endpoint with the provided access token', async () => {
+        const mock = new MockAdapter(axios);
+        mock.onGet().reply(200, {
+          id: 'prof_123',
+          idp_id: '123',
+          connection_id: 'conn_123',
+          connection_type: 'OktaSAML',
+          email: 'foo@test.com',
+          first_name: 'foo',
+          last_name: 'bar',
+          raw_attributes: {
+            email: 'foo@test.com',
+            first_name: 'foo',
+            last_name: 'bar',
+          },
+        });
+
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+        const profile = await workos.sso.getProfile({
+          accessToken: 'access_token',
+        });
+
+        expect(mock.history.get.length).toBe(1);
+        const { headers } = mock.history.get[0];
+        expect(headers.Authorization).toBe(`Bearer access_token`);
+
+        expect(profile.id).toBe('prof_123');
+      });
+    });
+
     describe('deleteConnection', () => {
       it('sends request to delete a Connection', async () => {
         const mock = new MockAdapter(axios);

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -4,8 +4,10 @@ import { WorkOS } from '../workos';
 import { AuthorizationURLOptions } from './interfaces/authorization-url-options.interface';
 import { Connection } from './interfaces/connection.interface';
 import { GetProfileAndTokenOptions } from './interfaces/get-profile-and-token-options.interface';
+import { GetProfileOptions } from './interfaces/get-profile-options.interface';
 import { ListConnectionsOptions } from './interfaces/list-connections-options.interface';
 import { ProfileAndToken } from './interfaces/profile-and-token.interface';
+import { Profile } from './interfaces/profile.interface';
 
 export class SSO {
   constructor(private readonly workos: WorkOS) {}
@@ -61,10 +63,20 @@ export class SSO {
     return data;
   }
 
+  async getProfile({ accessToken }: GetProfileOptions): Promise<Profile> {
+    const { data } = await this.workos.get('/sso/profile', {
+      accessToken,
+    });
+
+    return data;
+  }
+
   async listConnections(
     options?: ListConnectionsOptions,
   ): Promise<List<Connection>> {
-    const { data } = await this.workos.get(`/connections`, options);
+    const { data } = await this.workos.get(`/connections`, {
+      query: options,
+    });
     return data;
   }
 }

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -8,7 +8,12 @@ import {
   UnauthorizedException,
   UnprocessableEntityException,
 } from './common/exceptions';
-import { PostOptions, PutOptions, WorkOSOptions } from './common/interfaces';
+import {
+  GetOptions,
+  PostOptions,
+  PutOptions,
+  WorkOSOptions,
+} from './common/interfaces';
 import { DirectorySync } from './directory-sync/directory-sync';
 import { Organizations } from './organizations/organizations';
 import { Passwordless } from './passwordless/passwordless';
@@ -104,10 +109,17 @@ export class WorkOS {
     }
   }
 
-  async get(path: string, query?: any): Promise<AxiosResponse> {
+  async get(path: string, options: GetOptions = {}): Promise<AxiosResponse> {
     try {
+      const { accessToken } = options;
+
       return await this.client.get(path, {
-        params: query,
+        params: options.query,
+        headers: accessToken
+          ? {
+              Authorization: `Bearer ${accessToken}`,
+            }
+          : undefined,
       });
     } catch (error) {
       const { response } = error as AxiosError;


### PR DESCRIPTION
This PR adds a `getProfile` (no, not that one) method for calling the `/sso/profile` endpoint.

Resolves SDK-189.