### PR TITLE
Add `expiresIn` to `CreatePasswordlessSessionOptions`

### DIFF
--- a/src/passwordless/interfaces/create-passwordless-session-options.interface.ts
+++ b/src/passwordless/interfaces/create-passwordless-session-options.interface.ts
@@ -1,7 +1,8 @@
 export interface CreatePasswordlessSessionOptions {
+  type: 'MagicLink';
   email: string;
   redirectURI?: string;
   state?: string;
   connection?: string;
-  type: 'MagicLink';
+  expiresIn?: number;
 }

--- a/src/passwordless/passwordless.ts
+++ b/src/passwordless/passwordless.ts
@@ -8,11 +8,13 @@ export class Passwordless {
 
   async createSession({
     redirectURI,
+    expiresIn,
     ...options
   }: CreatePasswordlessSessionOptions): Promise<PasswordlessSession> {
     const { data } = await this.workos.post('/passwordless/sessions', {
       ...options,
       redirect_uri: redirectURI,
+      expires_in: expiresIn,
     });
     return data;
   }


### PR DESCRIPTION
This PR adds an optional `expiresIn` property to the `CreatePasswordlessSessionOptions`.

This property can be used to provide the time until the session expires (in seconds).