### PR TITLE
Add named export for CommonJS consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 yarn-error.log
 dist
+lib/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .npmrc
 node_modules
 yarn-error.log
-dist
 lib/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+**/*.spec.js
+**/*.spec.d.ts

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/workos-inc/workos-node/issues"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p .",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "node": "14.17.3",
     "yarn": "1.22.10"
   },
-  "main": "dist/src/index.js",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "files": [
-    "dist/**/*"
+    "lib/"
   ],
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,7 @@ export * from './passwordless/interfaces';
 export * from './portal/interfaces';
 export * from './sso/interfaces';
 
+export { WorkOS };
+
 // tslint:disable-next-line:no-default-export
 export default WorkOS;

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
-import { version } from '../package.json';
 import { AuditTrail } from './audit-trail/audit-trail';
 import {
   GenericServerException,
@@ -20,6 +19,8 @@ import { Organizations } from './organizations/organizations';
 import { Passwordless } from './passwordless/passwordless';
 import { Portal } from './portal/portal';
 import { SSO } from './sso/sso';
+
+const VERSION = '1.1.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 
@@ -60,7 +61,7 @@ export class WorkOS {
       baseURL: this.baseURL,
       headers: {
         Authorization: `Bearer ${this.key}`,
-        'User-Agent': `workos-node/${version}`,
+        'User-Agent': `workos-node/${VERSION}`,
       },
     });
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,19 @@
 {
   "compilerOptions": {
-    "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "alwaysStrict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "preserve",
-    "lib": ["dom", "es2017"],
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
-    "typeRoots": ["./node_modules/@types"],
     "target": "es6",
     "module": "commonjs",
     "declaration": true,
-    "outDir": "./dist",
+    "outDir": "lib",
     "strict": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/*.spec.ts", "dist"]
+  "include": ["src"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -16,7 +16,8 @@
     "quotemark": [true, "single", "jsx-double"],
     "variable-name": [true, "allow-leading-underscore"],
     "semicolon": [true, "always", "ignore-bound-class-methods"],
-    "no-default-export": true
+    "no-default-export": true,
+    "no-shadowed-variable": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
This PR adds a named `WorkOS` export for the SDK to facilitate more ergonomic usage by CommonJS users.

#### CommonJS

```js
const { WorkOS } = require('@workos-inc/node');

const workos = new WorkOS('sk_example_123456789');
```

#### ES Modules

```ts
import WorkOS from '@workos-inc/node';

const workos = new WorkOS('sk_example_123456789');
```

or

```ts
import { WorkOS } from '@workos-inc/node';

const workos = new WorkOS('sk_example_123456789');
```

Resolves SDK-76.