### PR TITLE
Expose `custom_attributes` for directory users

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -86,6 +86,82 @@ describe('DirectorySync', () => {
         });
         expect(mock.history.get[0].url).toEqual('/directory_users');
       });
+
+      describe('with custom attributes', () => {
+        it('returns the custom attributes, using the provided type', async () => {
+          interface MyCustomAttributes {
+            managerId: string;
+          }
+
+          mock.onGet().reply(200, {
+            data: [
+              {
+                object: 'directory_user',
+                id: 'directory_user_01FBSYNGBVB4Q0GE4PJR328QB6',
+                directory_id: 'directory_01FBSYNGBN6R6WRMQM47PRCVMH',
+                idp_id: 'd899102f-86ad-4c14-9629-cd478b6a1971',
+                username: 'Virginia.Stoltenberg92',
+                emails: [],
+                first_name: 'Virginia',
+                last_name: 'Stoltenberg',
+                state: 'active',
+                raw_attributes: {},
+                custom_attributes: {
+                  managerId: '99f1817b-149c-4438-b80f-a272c3406109',
+                },
+                groups: [
+                  {
+                    object: 'directory_group',
+                    id: 'directory_group_01FBSYNGC0ASXP1WPA32AF8430',
+                    directory_id: 'directory_01FBSYNGBN6R6WRMQM47PRCVMH',
+                    name: 'Strosin, Luettgen and Halvorson',
+                    raw_attributes: {},
+                  },
+                ],
+              },
+              {
+                object: 'directory_user',
+                id: 'directory_user_01FBSYQPYWG0SMTGRFFDS5FRQ9',
+                directory_id: 'directory_01FBSYQPYN2XMDN7BQHP490M03',
+                idp_id: '044d1610-7b9f-47bf-8269-9a5774a7a0d7',
+                username: 'Eli.Leffler',
+                emails: [],
+                first_name: 'Eli',
+                last_name: 'Leffler',
+                state: 'active',
+                raw_attributes: {},
+                custom_attributes: {
+                  managerId: '263c7472-4d3f-4ab4-8162-e768af103065',
+                },
+                groups: [
+                  {
+                    object: 'directory_group',
+                    id: 'directory_group_01FBSYQPZ101G15H9VJ5AM35Y3',
+                    directory_id: 'directory_01FBSYQPYN2XMDN7BQHP490M03',
+                    name: 'Osinski, Bauch and Rice',
+                    raw_attributes: {},
+                  },
+                ],
+              },
+            ],
+          });
+          const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+          const users =
+            await workos.directorySync.listUsers<MyCustomAttributes>({
+              directory: 'directory_123',
+            });
+
+          const managerIds = users.data.map(
+            (user) => user.custom_attributes.managerId,
+          );
+
+          expect(managerIds).toEqual([
+            '99f1817b-149c-4438-b80f-a272c3406109',
+            '263c7472-4d3f-4ab4-8162-e768af103065',
+          ]);
+        });
+      });
     });
 
     describe('with a Group', () => {

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -2,7 +2,10 @@ import { WorkOS } from '../workos';
 import { Directory } from './interfaces/directory.interface';
 import { List } from '../common/interfaces/list.interface';
 import { Group } from './interfaces/group.interface';
-import { UserWithGroups } from './interfaces/user.interface';
+import {
+  DefaultCustomAttributes,
+  UserWithGroups,
+} from './interfaces/user.interface';
 import { ListDirectoriesOptions } from './interfaces/list-directories-options.interface';
 import { ListGroupsOptions } from './interfaces/list-groups-options.interface';
 import { ListUsersOptions } from './interfaces/list-users-options.interface';
@@ -30,14 +33,18 @@ export class DirectorySync {
     return data;
   }
 
-  async listUsers(options: ListUsersOptions): Promise<List<UserWithGroups>> {
+  async listUsers<TCustomAttributes extends object = DefaultCustomAttributes>(
+    options: ListUsersOptions,
+  ): Promise<List<UserWithGroups<TCustomAttributes>>> {
     const { data } = await this.workos.get(`/directory_users`, {
       query: options,
     });
     return data;
   }
 
-  async getUser(user: string): Promise<UserWithGroups> {
+  async getUser<TCustomAttributes extends object = DefaultCustomAttributes>(
+    user: string,
+  ): Promise<UserWithGroups<TCustomAttributes>> {
     const { data } = await this.workos.get(`/directory_users/${user}`);
     return data;
   }

--- a/src/directory-sync/interfaces/user.interface.ts
+++ b/src/directory-sync/interfaces/user.interface.ts
@@ -1,8 +1,13 @@
 import { Group } from './group.interface';
 
-export interface User {
+export type DefaultCustomAttributes = Record<string, unknown>;
+
+export interface User<
+  TCustomAttributes extends object = DefaultCustomAttributes,
+> {
   id: string;
   raw_attributes: any;
+  custom_attributes: TCustomAttributes;
   idp_id: string;
   first_name: string;
   emails: {
@@ -15,6 +20,8 @@ export interface User {
   state: 'active' | 'suspended';
 }
 
-export interface UserWithGroups extends User {
+export interface UserWithGroups<
+  TCustomAttributes extends object = DefaultCustomAttributes,
+> extends User<TCustomAttributes> {
   groups: Group[];
 }


### PR DESCRIPTION
This PR exposes the `custom_attributes` field for directory users.

We provide a `TCustomAttributes` type parameter that allows for the type of `custom_attributes` to be customized based on which custom attributes are defined. By default we treat this as a `Record<string, unknown>`.

Resolves SDK-245.