### PR TITLE
Add created_at and updated_at fields

### DIFF
--- a/src/directory-sync/interfaces/directory.interface.ts
+++ b/src/directory-sync/interfaces/directory.interface.ts
@@ -8,4 +8,6 @@ export interface Directory {
   organization_id: string;
   state: 'unlinked' | 'linked' | 'invalid_credentials';
   type: string;
+  created_at: string;
+  updated_at: string;
 }

--- a/src/organizations/interfaces/organization.interface.ts
+++ b/src/organizations/interfaces/organization.interface.ts
@@ -5,4 +5,6 @@ export interface Organization {
   id: string;
   name: string;
   domains: OrganizationDomain[];
+  created_at: string;
+  updated_at: string;
 }

--- a/src/sso/interfaces/connection.interface.ts
+++ b/src/sso/interfaces/connection.interface.ts
@@ -18,4 +18,6 @@ export interface Connection {
    */
   status: 'linked' | 'unlinked';
   domains: ConnectionDomain[];
+  created_at: string;
+  updated_at: string;
 }


### PR DESCRIPTION
https://linear.app/workos/issue/SDK-250/add-created-at-and-updated-at-fields-to-node-sdk

Adds `created_at` and `updated_at` fields to Connections, Directories, and Organizations.