### PR TITLE
Add support for `allow_profiles_outside_organization` for organizations

### DIFF
--- a/src/organizations/fixtures/create-organization.json
+++ b/src/organizations/fixtures/create-organization.json
@@ -2,6 +2,7 @@
   "name": "Test Organization",
   "object": "organization",
   "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
+  "allow_profiles_outside_organization": false,
   "domains": [
     {
       "domain": "example.com",

--- a/src/organizations/fixtures/get-organization.json
+++ b/src/organizations/fixtures/get-organization.json
@@ -2,6 +2,7 @@
   "name": "Test Organization 3",
   "object": "organization",
   "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
+  "allow_profiles_outside_organization": false,
   "domains": [
     {
       "domain": "example.com",

--- a/src/organizations/fixtures/list-organizations.json
+++ b/src/organizations/fixtures/list-organizations.json
@@ -5,6 +5,7 @@
       "object": "organization",
       "id": "org_01EHQMYV6MBK39QC5PZXHY59C3",
       "name": "example.com",
+      "allow_profiles_outside_organization": false,
       "domains": [
         {
           "object": "organization_domain",
@@ -17,6 +18,7 @@
       "object": "organization",
       "id": "org_01EHQMVDTC2GRAHFCCRNTSKH46",
       "name": "example2.com",
+      "allow_profiles_outside_organization": false,
       "domains": [
         {
           "object": "organization_domain",
@@ -29,6 +31,7 @@
       "object": "organization",
       "id": "org_01EGS4P7QR31EZ4YWD1Z1XA176",
       "name": "foo-corp.com",
+      "allow_profiles_outside_organization": false,
       "domains": [
         {
           "object": "organization_domain",
@@ -41,6 +44,7 @@
       "object": "organization",
       "id": "org_01EGPYFYM0Y66AHNYQG9Z63DTN",
       "name": "example3.com",
+      "allow_profiles_outside_organization": false,
       "domains": [
         {
           "object": "organization_domain",
@@ -53,6 +57,7 @@
       "object": "organization",
       "id": "org_01EGPJWMT2EQMK7FMPR3TBC861",
       "name": "workos.com",
+      "allow_profiles_outside_organization": false,
       "domains": [
         {
           "object": "organization_domain",
@@ -65,6 +70,7 @@
       "object": "organization",
       "id": "org_01EGPJ5YY5P897573GJFGGY7ZF",
       "name": "example4.com",
+      "allow_profiles_outside_organization": false,
       "domains": [
         {
           "object": "organization_domain",
@@ -77,6 +83,7 @@
       "object": "organization",
       "id": "org_01EGP9Z6RY2J6YE0ZV57CGEXV2",
       "name": "example5.com",
+      "allow_profiles_outside_organization": false,
       "domains": [
         {
           "object": "organization_domain",

--- a/src/organizations/fixtures/update-organization.json
+++ b/src/organizations/fixtures/update-organization.json
@@ -2,6 +2,7 @@
   "name": "Test Organization 2",
   "object": "organization",
   "id": "org_01EHT88Z8J8795GZNQ4ZP1J81T",
+  "allow_profiles_outside_organization": false,
   "domains": [
     {
       "domain": "example.com",

--- a/src/organizations/interfaces/create-organization-options.interface.ts
+++ b/src/organizations/interfaces/create-organization-options.interface.ts
@@ -1,5 +1,4 @@
-export interface UpdateOrganizationOptions {
-  organization: string;
+export interface CreateOrganizationOptions {
   name: string;
   allow_profiles_outside_organization?: boolean;
   domains?: string[];

--- a/src/organizations/interfaces/index.ts
+++ b/src/organizations/interfaces/index.ts
@@ -1,3 +1,4 @@
+export * from './create-organization-options.interface';
 export * from './list-organizations-options.interface';
 export * from './organization-domain.interface';
 export * from './organization.interface';

--- a/src/organizations/interfaces/organization.interface.ts
+++ b/src/organizations/interfaces/organization.interface.ts
@@ -4,6 +4,7 @@ export interface Organization {
   object: 'organization';
   id: string;
   name: string;
+  allow_profiles_outside_organization: boolean;
   domains: OrganizationDomain[];
   created_at: string;
   updated_at: string;

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -157,6 +157,7 @@ describe('Organizations', () => {
       );
       expect(subject.id).toEqual('org_01EHT88Z8J8795GZNQ4ZP1J81T');
       expect(subject.name).toEqual('Test Organization 3');
+      expect(subject.allow_profiles_outside_organization).toEqual(false);
       expect(subject.domains).toHaveLength(1);
     });
   });

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -1,6 +1,7 @@
 import { List } from '../common/interfaces/list.interface';
 import { WorkOS } from '../workos';
 import {
+  CreateOrganizationOptions,
   ListOrganizationsOptions,
   Organization,
   UpdateOrganizationOptions,
@@ -19,17 +20,10 @@ export class Organizations {
     return data;
   }
 
-  async createOrganization({
-    domains,
-    name,
-  }: {
-    domains?: string[];
-    name: string;
-  }): Promise<Organization> {
-    const { data } = await this.workos.post('/organizations', {
-      domains,
-      name,
-    });
+  async createOrganization(
+    payload: CreateOrganizationOptions,
+  ): Promise<Organization> {
+    const { data } = await this.workos.post('/organizations', payload);
 
     return data;
   }


### PR DESCRIPTION
This PR adds support for the `allow_profiles_outside_organization` field for organization objects and operations.

Resolves SDK-256.