### PR TITLE
Use non-deprecated form of `list_metadata`

### DIFF
--- a/src/audit-trail/audit-trail.spec.ts
+++ b/src/audit-trail/audit-trail.spec.ts
@@ -149,7 +149,7 @@ describe('AuditTrail', () => {
               },
             },
           ],
-          listMetadata: { before: null, after: null },
+          list_metadata: { before: null, after: null },
         });
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
@@ -184,7 +184,7 @@ describe('AuditTrail', () => {
               },
             },
           ],
-          listMetadata: { before: null, after: null },
+          list_metadata: { before: null, after: null },
         });
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');

--- a/src/common/interfaces/list.interface.ts
+++ b/src/common/interfaces/list.interface.ts
@@ -1,7 +1,7 @@
 export interface List<T> {
+  readonly object: 'list';
   data: T[];
-
-  listMetadata: {
+  list_metadata: {
     before?: string;
     after?: string;
   };

--- a/src/organizations/fixtures/list-organizations.json
+++ b/src/organizations/fixtures/list-organizations.json
@@ -93,5 +93,5 @@
       ]
     }
   ],
-  "listMetadata": { "before": "before-id", "after": null }
+  "list_metadata": { "before": "before-id", "after": null }
 }

--- a/src/organizations/organizations.spec.ts
+++ b/src/organizations/organizations.spec.ts
@@ -18,7 +18,7 @@ describe('Organizations', () => {
       it('returns organizations and metadata', async () => {
         mock.onGet().reply(200, listOrganizationsFixture);
 
-        const { data, listMetadata } =
+        const { data, list_metadata: listMetadata } =
           await workos.organizations.listOrganizations();
 
         expect(mock.history.get[0].params).toBeUndefined();


### PR DESCRIPTION
This PR updates the `List` type to use `list_metadata` instead of `listMetadata`.

This is a breaking change.

Resolves SDK-313.