### PR TITLE
v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "2.0.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -19,7 +19,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/1.6.0",
+  "User-Agent": "workos-node/2.0.0",
 }
 `;
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -21,7 +21,7 @@ import { Portal } from './portal/portal';
 import { SSO } from './sso/sso';
 import { Webhooks } from './webhooks/webhooks';
 
-const VERSION = '1.6.0';
+const VERSION = '2.0.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
## Breaking Changes

- The `organization_id` field on the following objects is now nullable (#504):
  - `Connection`
  - `Directory`
  - `Profile`
- The `listMetadata` field on the `List` type has been renamed to `list_metadata` (#508)

## New Features

- Added types for webhook events (#506)