### PR TITLE
Add Get a Directory endpoint

### DIFF
--- a/src/directory-sync/directory-sync.spec.ts
+++ b/src/directory-sync/directory-sync.spec.ts
@@ -26,6 +26,17 @@ describe('DirectorySync', () => {
     });
   });
 
+  describe('getDirectory', () => {
+    it(`requests a Directory`, async () => {
+      mock.onGet().reply(200, {});
+      const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+      await workos.directorySync.getDirectory('directory_123');
+
+      expect(mock.history.get[0].url).toEqual('/directories/directory_123');
+    });
+  });
+
   describe('deleteDirectory', () => {
     it('sends a request to delete the directory', async () => {
       mock.onDelete().reply(202, {});

--- a/src/directory-sync/directory-sync.ts
+++ b/src/directory-sync/directory-sync.ts
@@ -22,6 +22,11 @@ export class DirectorySync {
     return data;
   }
 
+  async getDirectory(id: string): Promise<Directory> {
+    const { data } = await this.workos.get(`/directories/${id}`);
+    return data;
+  }
+
   async deleteDirectory(id: string) {
     await this.workos.delete(`/directories/${id}`);
   }


### PR DESCRIPTION
https://linear.app/workos/issue/SDK-327/get-a-directory-endpoint-for-node-sdk

Adds a Get a Directory endpoint for Directory Sync.