### PR TITLE
fix: add `directory_id` property to `DsyncUser*Webhook` interfaces

### DIFF
--- a/src/webhooks/interfaces/webhook.interface.ts
+++ b/src/webhooks/interfaces/webhook.interface.ts
@@ -77,17 +77,23 @@ export interface DsyncGroupUserRemovedWebhook extends WebhookBase {
 
 export interface DsyncUserCreatedWebhook extends WebhookBase {
   event: 'dsync.user.created';
-  data: User;
+  data: User & {
+    directory_id: string;
+  };
 }
 
 export interface DsyncUserDeletedWebhook extends WebhookBase {
   event: 'dsync.user.deleted';
-  data: User;
+  data: User & {
+    directory_id: string;
+  };
 }
 
 export interface DsyncUserUpdatedWebhook extends WebhookBase {
   event: 'dsync.user.updated';
-  data: User;
+  data: User & {
+    directory_id: string;
+  };
 }
 
 export type Webhook =


### PR DESCRIPTION
### Context

The `directory_id` property is observed in the webhook request body but it is not available on the `DsyncUser*Webhook` interfaces.

This PR adds the missing `directory_id` property to all directory sync webhook event interfaces' `data` property.

### Example `dsync.user.created` webhook request body

```js
{
    "id": "wh_01FKZ41WJYEG7ZQTAN6AZ47P6P",
    "data": {
        // ...
        "last_name": "Liau",
        "first_name": "Jian Jie",
        "directory_id": "directory_01FKZ3ZTD2Z5F1093YTKNBWVMJ", // <- this is present but not represented in the interface
        // ...
    },
    "event": "dsync.user.created"
}
```