### PR TITLE
Fix missing directory_id on user webhook event

### DIFF
--- a/src/directory-sync/interfaces/group.interface.ts
+++ b/src/directory-sync/interfaces/group.interface.ts
@@ -1,5 +1,6 @@
 export interface Group {
   id: string;
+  directory_id: string;
   name: string;
   raw_attributes: any;
 }

--- a/src/directory-sync/interfaces/user.interface.ts
+++ b/src/directory-sync/interfaces/user.interface.ts
@@ -6,6 +6,7 @@ export interface User<
   TCustomAttributes extends object = DefaultCustomAttributes,
 > {
   id: string;
+  directory_id: string;
   raw_attributes: any;
   custom_attributes: TCustomAttributes;
   idp_id: string;

--- a/src/webhooks/interfaces/webhook.interface.ts
+++ b/src/webhooks/interfaces/webhook.interface.ts
@@ -38,23 +38,17 @@ export interface DsyncDeletedWebhook extends WebhookBase {
 
 export interface DsyncGroupCreatedWebhook extends WebhookBase {
   event: 'dsync.group.created';
-  data: Group & {
-    directory_id: string;
-  };
+  data: Group;
 }
 
 export interface DsyncGroupDeletedWebhook extends WebhookBase {
   event: 'dsync.group.deleted';
-  data: Group & {
-    directory_id: string;
-  };
+  data: Group;
 }
 
 export interface DsyncGroupUpdatedWebhook extends WebhookBase {
   event: 'dsync.group.updated';
-  data: Group & {
-    directory_id: string;
-  };
+  data: Group;
 }
 
 export interface DsyncGroupUserAddedWebhook extends WebhookBase {
@@ -77,17 +71,17 @@ export interface DsyncGroupUserRemovedWebhook extends WebhookBase {
 
 export interface DsyncUserCreatedWebhook extends WebhookBase {
   event: 'dsync.user.created';
-  data: User & { directory_id: string };
+  data: User;
 }
 
 export interface DsyncUserDeletedWebhook extends WebhookBase {
   event: 'dsync.user.deleted';
-  data: User & { directory_id: string };
+  data: User;
 }
 
 export interface DsyncUserUpdatedWebhook extends WebhookBase {
   event: 'dsync.user.updated';
-  data: User & { directory_id: string };
+  data: User;
 }
 
 export type Webhook =

--- a/src/webhooks/interfaces/webhook.interface.ts
+++ b/src/webhooks/interfaces/webhook.interface.ts
@@ -77,17 +77,17 @@ export interface DsyncGroupUserRemovedWebhook extends WebhookBase {
 
 export interface DsyncUserCreatedWebhook extends WebhookBase {
   event: 'dsync.user.created';
-  data: User;
+  data: User & { directory_id: string };
 }
 
 export interface DsyncUserDeletedWebhook extends WebhookBase {
   event: 'dsync.user.deleted';
-  data: User;
+  data: User & { directory_id: string };
 }
 
 export interface DsyncUserUpdatedWebhook extends WebhookBase {
   event: 'dsync.user.updated';
-  data: User;
+  data: User & { directory_id: string };
 }
 
 export type Webhook =


### PR DESCRIPTION
# About

Fix missing attribute on user webhook events

> Note: I haven't looked into whether `directory_id` should be present on all uses of the `User` interface (or if this "merged" type is only used in webhooks