### PR TITLE
Update default tolerance to 3 minutes

### DIFF
--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -7,7 +7,7 @@ export class Webhooks {
     payload,
     sigHeader,
     secret,
-    tolerance = 180,
+    tolerance = 180000,
   }: {
     payload: unknown;
     sigHeader: string;
@@ -25,7 +25,7 @@ export class Webhooks {
     payload,
     sigHeader,
     secret,
-    tolerance = 180,
+    tolerance = 180000,
   }: {
     payload: any;
     sigHeader: string;


### PR DESCRIPTION
According to the documentation, tolerances are between '3-5 minutes'. This library is instead validating against 180 milliseconds
This PR updates the default values to 3 minutes