### PR TITLE
Add support for `organization` parameter

### DIFF
--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -6,9 +6,11 @@ exports[`SSO SSO getAuthorizationURL with a custom api hostname generates an aut
 
 exports[`SSO SSO getAuthorizationURL with a provider generates an authorize url with the provider 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&provider=Google&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
+exports[`SSO SSO getAuthorizationURL with an \`organization\` generates an authorization URL with the organization 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&organization=organization_123&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
+
 exports[`SSO SSO getAuthorizationURL with no custom api hostname generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code"`;
 
-exports[`SSO SSO getAuthorizationURL with no domain or provider throws an error for incomplete arguments 1`] = `"Incomplete arguments. Need to specify either a 'connection', 'domain', or 'provider'."`;
+exports[`SSO SSO getAuthorizationURL with no domain or provider throws an error for incomplete arguments 1`] = `"Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'."`;
 
 exports[`SSO SSO getAuthorizationURL with state generates an authorize url with the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom%20state"`;
 

--- a/src/sso/interfaces/authorization-url-options.interface.ts
+++ b/src/sso/interfaces/authorization-url-options.interface.ts
@@ -1,6 +1,11 @@
 export interface AuthorizationURLOptions {
   clientID: string;
   connection?: string;
+  organization?: string;
+
+  /**
+   * @deprecated Please use `organization` instead.
+   */
   domain?: string;
   provider?: string;
   redirectURI: string;

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -66,6 +66,22 @@ describe('SSO', () => {
         });
       });
 
+      describe('with an `organization`', () => {
+        it('generates an authorization URL with the organization', () => {
+          const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+            apiHostname: 'api.workos.dev',
+          });
+
+          const url = workos.sso.getAuthorizationURL({
+            organization: 'organization_123',
+            clientID: 'proj_123',
+            redirectURI: 'example.com/sso/workos/callback',
+          });
+
+          expect(url).toMatchSnapshot();
+        });
+      });
+
       describe('with a custom api hostname', () => {
         it('generates an authorize url with the custom api hostname', () => {
           const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -20,18 +20,26 @@ export class SSO {
     connection,
     clientID,
     domain,
+    organization,
     provider,
     redirectURI,
     state,
   }: AuthorizationURLOptions): string {
-    if (!domain && !provider && !connection) {
+    if (!domain && !provider && !connection && !organization) {
       throw new Error(
-        `Incomplete arguments. Need to specify either a 'connection', 'domain', or 'provider'.`,
+        `Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'.`,
+      );
+    }
+
+    if (domain) {
+      this.workos.emitWarning(
+        'The `domain` parameter for `getAuthorizationURL` is deprecated. Please use `organization` instead.',
       );
     }
 
     const query = queryString.stringify({
       connection,
+      organization,
       domain,
       provider,
       client_id: clientID,


### PR DESCRIPTION
This PR adds support for the `organization` parameter to initiate SSO.

As part of this, the `domain` parameter has also been deprecated in favor of `organization`.

Resolves SDK-353.