### PR TITLE
v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.3.0",
   "name": "@workos-inc/node",
   "author": "WorkOS",
   "description": "A Node wrapper for the WorkOS API",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -21,7 +21,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-  "User-Agent": "workos-node/2.2.0",
+  "User-Agent": "workos-node/2.3.0",
 }
 `;
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -21,7 +21,7 @@ import { Portal } from './portal/portal';
 import { SSO } from './sso/sso';
 import { Webhooks } from './webhooks/webhooks';
 
-const VERSION = '2.2.0';
+const VERSION = '2.3.0';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 


### PR DESCRIPTION
### Added

- Added support for passing an `organization` to `sso.getAuthorizationURL` (#537)

### Changed

- Increased the default `tolerance` for `webhooks.constructEvent` to three minutes (#530)

### Deprecated

- Deprecated the `domain` parameter for `sso.getAuthorizationURL` in favor of `organization` (#537)
