### PR TITLE
Export organization type definitions at top level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './audit-trail/interfaces';
 export * from './common/exceptions';
 export * from './common/interfaces';
 export * from './directory-sync/interfaces';
+export * from './organizations/interfaces';
 export * from './passwordless/interfaces';
 export * from './portal/interfaces';
 export * from './sso/interfaces';


### PR DESCRIPTION
I'm building a wrapper around the WorkOS client in TypeScript and noticed that types such as `Organization` and `CreateOrganizationOptions` are not exported by `@workos-inc/node`. Instead I had to import them from `@workos-inc/node/lib/organizations/interfaces`.