### PR TITLE
Add organization_id parameter to listDirectories method

### DIFF
--- a/src/directory-sync/interfaces/list-directories-options.interface.ts
+++ b/src/directory-sync/interfaces/list-directories-options.interface.ts
@@ -2,5 +2,6 @@ import { PaginationOptions } from '../../common/interfaces/pagination-options.in
 
 export interface ListDirectoriesOptions extends PaginationOptions {
   domain?: string;
+  organization_id: string;
   search?: string;
 }

--- a/src/directory-sync/interfaces/list-directories-options.interface.ts
+++ b/src/directory-sync/interfaces/list-directories-options.interface.ts
@@ -2,6 +2,6 @@ import { PaginationOptions } from '../../common/interfaces/pagination-options.in
 
 export interface ListDirectoriesOptions extends PaginationOptions {
   domain?: string;
-  organization_id: string;
+  organization_id?: string;
   search?: string;
 }


### PR DESCRIPTION
resolves SUP-267 https://linear.app/workos/issue/SUP-267/node-sdk-add-organization-id-filter-to-list-directories-method